### PR TITLE
Fixed getting IP address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-# Version: 0.0.1
+# Version: 0.0.2
 
 FROM erben22/rpi-rtlsdr-base
-MAINTAINER Stewart Cossey
+MAINTAINER R. Cody Erben
 ENV REFRESHED_AT 2018-10-26
 
-# Forked from Cody Erben, cheers mate!
 # Expose the well-known-ish rtl_tcp port of 1234, and then
 # our ENTRYPOINT is the rtl_tcp program bound to the
 # containers externally-available interface.  Without -a,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Version: 0.0.1
 
 FROM erben22/rpi-rtlsdr-base
-MAINTAINER R. Cody Erben
-ENV REFRESHED_AT 2016-05-07
+MAINTAINER Stewart Cossey
+ENV REFRESHED_AT 2018-10-26
 
+# Forked from Cody Erben, cheers mate!
 # Expose the well-known-ish rtl_tcp port of 1234, and then
 # our ENTRYPOINT is the rtl_tcp program bound to the
 # containers externally-available interface.  Without -a,

--- a/launch-rtl-tcp.bash
+++ b/launch-rtl-tcp.bash
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-IP="$(ifconfig eth0 | awk -F ' *|:' '/inet addr/{print $4}')"
+IP="$(hostname -i)"
 /usr/local/bin/rtl_tcp -a ${IP}


### PR DESCRIPTION
The original method of getting the IP address of the container used in the launch script no longer works with current versions of Docker. 

I have changed the launch script to use the recommend "hostname -i" command to return the IP address and this now correctly executes on my raspberry pi.